### PR TITLE
Waiter updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,3 +48,17 @@ test:
 
 testacc:
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
+
+resource:
+	cp ./internal/provider/assets/aws/acm/resources.go ./internal/provider/assets/aws/ecs/resources.go
+	sed -i 's/package acm/package ecs/g' ./internal/provider/assets/aws/ecs/resources.go
+
+	cp ./internal/provider/assets/aws/acm/resources.go ./internal/provider/assets/aws/rds/resources.go
+	sed -i 's/package acm/package rds/g' ./internal/provider/assets/aws/rds/resources.go
+
+	cp ./internal/provider/assets/aws/acm/resources.go ./internal/provider/assets/aws/redis/resources.go
+	sed -i 's/package acm/package redis/g' ./internal/provider/assets/aws/redis/resources.go
+
+	cp ./internal/provider/assets/aws/acm/resources.go ./internal/provider/assets/aws/vpc/resources.go
+	sed -i 's/package acm/package vpc/g' ./internal/provider/assets/aws/vpc/resources.go
+.PHONY: resource

--- a/examples/aws/main.tf
+++ b/examples/aws/main.tf
@@ -18,13 +18,13 @@ provider "aptible" {
 }
 
 variable "organization_id" {
-  type = string
+  type    = string
   default = "2253ae98-d65a-4180-aceb-8419b7416677"
 }
 
 variable "environment_id" {
-  type = string
-  default = "238930f4-0750-4f55-b43c-e1a11c437e23"
+  type    = string
+  default = "b47357cd-2971-4f73-ad6f-2edbddcde529"
 }
 
 data "aptible_organization" "org" {
@@ -32,50 +32,52 @@ data "aptible_organization" "org" {
 }
 
 data "aptible_environment" "env" {
-  id = var.environment_id
-  org_id = data.aptible_organization.org.id
+  id      = var.environment_id
+  org_id  = data.aptible_organization.org.id
 }
 
 resource "aptible_aws_vpc" "network" {
   environment_id  = data.aptible_environment.env.id
   organization_id = data.aptible_organization.org.id
   asset_version   = "latest"
-  name            = "my_vpc"
+  name            = "myvpc"
 }
 
 resource "aptible_aws_rds" "db" {
   environment_id  = data.aptible_environment.env.id
   organization_id = data.aptible_organization.org.id
   vpc_name        = aptible_aws_vpc.network.name
+  depends_on      = [aptible_aws_vpc.network]
 
   asset_version   = "latest"
-  name            = "dbnext" # force new
+  name            = "mydb" # force new
   engine          = "postgres"
   engine_version  = "14"
 }
 
 resource "aptible_aws_redis" "cache" {
-  environment_id = data.aptible_environment.env.id
-  organization_id = data.aptible_organization.org.id
-  vpc_name = aptible_aws_vpc.network.name
+  environment_id      = data.aptible_environment.env.id
+  organization_id     = data.aptible_organization.org.id
+  vpc_name            = aptible_aws_vpc.network.name
+  depends_on          = [aptible_aws_vpc.network]
 
-  asset_version  = "latest"
-  name = "appcache"
-  description = "integration testing"
-  snapshot_window = "00:00-01:00"
-  maintenance_window = "sun:10:00-sun:14:00"
+  asset_version       = "latest"
+  name                = "mycache"
+  description         = "integration testing"
+  snapshot_window     = "00:00-01:00"
+  maintenance_window  = "sun:10:00-sun:14:00"
 }
 
 resource "aptible_aws_acm" "cert" {
-  environment_id = data.aptible_environment.env.id
-  organization_id = data.aptible_organization.org.id
+  environment_id    = data.aptible_environment.env.id
+  organization_id   = data.aptible_organization.org.id
 
-  asset_version  = "latest"
-  fqdn = "eric.aptible-test-leeroy.com"
+  asset_version     = "latest"
+  fqdn              = "eric.aptible-test-leeroy.com"
   validation_method = "DNS"
 }
 
-data "aws_route53_zone" "example" {
+data "aws_route53_zone" "domains" {
   name         = "aptible-test-leeroy.com"
   private_zone = false
 }
@@ -90,82 +92,51 @@ locals {
   ]
 }
 
-resource "aws_route53_record" "example" {
+resource "aws_route53_record" "domains" {
   allow_overwrite = true
   name            = local.validation_dns.0.name
   records         = [local.validation_dns.0.record]
   ttl             = 60
   type            = local.validation_dns.0.type
-  zone_id         = data.aws_route53_zone.example.zone_id
+  zone_id         = data.aws_route53_zone.domains.zone_id
   depends_on      = [aptible_aws_acm.cert]
 }
 
 resource "time_sleep" "wait_30_seconds" {
-  depends_on      = [aws_route53_record.example]
+  depends_on      = [aws_route53_record.domains]
   create_duration = "30s"
 }
 
-#resource "aws_route53_record" "example" {
-#  for_each = {
-#    for dvo in aptible_aws_acm.cert.domain_validation_records : dvo.domain_name => {
-#      name   = dvo.resource_record_name
-#      record = dvo.resource_record_value
-#      type   = dvo.resource_record_type
-#    }
-#  }
-#
-#  allow_overwrite = true
-#  name            = each.value.name
-#  records         = [each.value.record]
-#  ttl             = 60
-#  type            = each.value.type
-#  zone_id         = data.aws_route53_zone.example.zone_id
-#}
-
 resource "aptible_aws_ecs_web" "web" {
-  environment_id = data.aptible_environment.env.id
-  organization_id = data.aptible_organization.org.id
-  vpc_name = aptible_aws_vpc.network.name
+  environment_id      = data.aptible_environment.env.id
+  organization_id     = data.aptible_organization.org.id
+  vpc_name            = aptible_aws_vpc.network.name
+  depends_on          = [time_sleep.wait_30_seconds]
 
-  asset_version  = "latest"
-  name = "myapp"
-  is_public = true
-  container_name = "myapp"
-  container_image = "quay.io/aptible/deploy-demo-app"
-  container_command = ["echo", "'hi there'"]
-  container_port = 5000
-  lb_cert_arn = aptible_aws_acm.cert.arn
-  lb_cert_domain = aptible_aws_acm.cert.fqdn
+  asset_version       = "latest"
+  name                = "myapp"
+  is_public           = true
+  container_name      = "myapp"
+  container_image     = "quay.io/aptible/deploy-demo-app"
+  container_command   = ["bash"]
+  container_port      = 5000
+  lb_cert_arn         = aptible_aws_acm.cert.arn
+  lb_cert_domain      = aptible_aws_acm.cert.fqdn
   environment_secrets = {
     DATABASE_URL = {
-      secret_arn = aptible_aws_rds.db.uri_secret_arn
-      secret_kms_arn = aptible_aws_rds.db.secrets_kms_key_arn,
+      secret_arn      = aptible_aws_rds.db.uri_secret_arn
+      secret_kms_arn  = aptible_aws_rds.db.secrets_kms_key_arn,
       secret_json_key = ""
     }
-    # TOKEN_SECRET = {
-    #   secret_arn = aptible_aws_redis.cache.uri_secret_arn,
-    #   secret_kms_arn = aptible_aws_redis.cache.secrets_kms_key_arn,
-    #   secret_json_key = "token"
-    # }
     REDIS_URL = {
-      secret_arn = aptible_aws_redis.cache.uri_secret_arn,
-      secret_kms_arn = aptible_aws_redis.cache.secrets_kms_key_arn,
+      secret_arn      = aptible_aws_redis.cache.uri_secret_arn,
+      secret_kms_arn  = aptible_aws_redis.cache.secrets_kms_key_arn,
       secret_json_key = "dsn"
     }
+    # TOKEN_SECRET = {
+    #   secret_arn      = aptible_aws_redis.cache.uri_secret_arn,
+    #   secret_kms_arn  = aptible_aws_redis.cache.secrets_kms_key_arn,
+    #   secret_json_key = "token"
+    # }
   }
-  depends_on = [time_sleep.wait_30_seconds]
 }
-
-#resource "aptible_connection" "web_to_rds" {
-#  inbound_id = aptible_aws_ecs_web.web.id
-#  outbound_id = aptible_aws_rds.cache.id
-#  inbound_label = "web"
-#  outbound_label = "rds"
-#}
-#
-#resource "aptible_connection" "web_to_redis" {
-#  inbound_id = aptible_aws_ecs_web.web.id
-#  outbound_id = aptible_aws_redis.db.id
-#  inbound_label = "web"
-#  outbount_label = "redis"
-#}

--- a/internal/provider/assets/aws/acm/models.go
+++ b/internal/provider/assets/aws/acm/models.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	cac "github.com/aptible/cloud-api-clients/clients/go"
 	"github.com/aptible/terraform-provider-aptible-iaas/internal/client"
@@ -130,8 +129,6 @@ type DnsData struct {
 func assetOutputToPlan(ctx context.Context, output *cac.AssetOutput) (*ResourceModel, error) {
 	outputs := *output.Outputs
 
-	tflog.Info(ctx, "--DVR--", map[string]interface{}{"state": outputs["dns_validation_records"]})
-
 	mapper := map[string]attr.Type{
 		"domain_name":           types.StringType,
 		"resource_record_name":  types.StringType,
@@ -163,7 +160,6 @@ func assetOutputToPlan(ctx context.Context, output *cac.AssetOutput) (*ResourceM
 			})
 		}
 	}
-	tflog.Info(ctx, "--RECORDS--", map[string]interface{}{"state": records})
 
 	arnRaw := outputs["acm_certificate_arn"].Data
 	arn := ""

--- a/internal/provider/assets/aws/ecs/models.go
+++ b/internal/provider/assets/aws/ecs/models.go
@@ -1,6 +1,7 @@
 package ecs
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -131,7 +132,7 @@ var AssetSchema = map[string]tfsdk.Attribute{
 	},
 }
 
-func planToAssetInput(plan ResourceModel) (cac.AssetInput, error) {
+func planToAssetInput(ctx context.Context, plan ResourceModel) (cac.AssetInput, error) {
 	cmd := []string{}
 	for _, c := range plan.ContainerCommand {
 		cmd = append(cmd, c.Value)
@@ -168,7 +169,7 @@ func planToAssetInput(plan ResourceModel) (cac.AssetInput, error) {
 	return input, nil
 }
 
-func assetOutputToPlan(output *cac.AssetOutput) (*ResourceModel, error) {
+func assetOutputToPlan(ctx context.Context, output *cac.AssetOutput) (*ResourceModel, error) {
 	cmd := []types.String{}
 	cmdList := output.CurrentAssetParameters.Data["container_command"].([]interface{})
 	for _, c := range cmdList {

--- a/internal/provider/assets/aws/ecs/resources.go
+++ b/internal/provider/assets/aws/ecs/resources.go
@@ -65,7 +65,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 
 	tflog.Info(ctx, "Creating asset", map[string]interface{}{"asset": plan})
 
-	assetInput, err := planToAssetInput(plan)
+	assetInput, err := planToAssetInput(ctx, plan)
 	if err != nil {
 		return
 	}
@@ -83,9 +83,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		)
 		return
 	}
-	// for more information on logging from providers, refer to
-	// https://pkg.go.dev/github.com/hashicorp/terraform-plugin-log/tflog
-	tflog.Trace(
+	tflog.Info(
 		ctx, "created asset",
 		map[string]interface{}{
 			"id":     createdAsset.Id,
@@ -93,32 +91,61 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		},
 	)
 
-	result, err := assetOutputToPlan(createdAsset)
+	nextPlan, err := assetOutputToPlan(ctx, createdAsset)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating asset",
-			"Error when creating asset"+plan.Id.Value+": "+err.Error(),
+			fmt.Sprintf(
+				"Error when creating asset %s: %s",
+				plan.Id.Value,
+				err.Error(),
+			),
 		)
 		return
 	}
 
-	diags = resp.State.Set(ctx, result)
+	diags = resp.State.Set(ctx, nextPlan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	if err := utils.WaitForAssetStatusInOperationCompleteState(
+	completedAsset, err := utils.WaitForAssetStatusInOperationCompleteState(
 		r.client,
 		ctx,
-		result.OrganizationId.Value,
-		result.EnvironmentId.Value,
-		result.Id.Value,
-	); err != nil {
+		plan.OrganizationId.Value,
+		plan.EnvironmentId.Value,
+		createdAsset.Id,
+	)
+
+	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error waiting for asset on create",
-			"Error when waiting for asset id"+result.Id.Value+": "+err.Error(),
+			fmt.Sprintf(
+				"Error when waiting for asset id %s: %s",
+				createdAsset.Id,
+				err.Error(),
+			),
 		)
+		return
+	}
+
+	nextPlan, err = assetOutputToPlan(ctx, completedAsset)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating asset",
+			fmt.Sprintf(
+				"Error when creating asset %s: %s",
+				plan.Id.Value,
+				err.Error(),
+			),
+		)
+		return
+	}
+
+	diags = resp.State.Set(ctx, nextPlan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 }
@@ -136,12 +163,16 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading asset",
-			"Could not read ID "+state.Id.Value+": "+err.Error(),
+			fmt.Sprintf(
+				"Error when creating asset %s: %s",
+				state.Id.Value,
+				err.Error(),
+			),
 		)
 		return
 	}
 
-	asset, err := assetOutputToPlan(assetClientOutput)
+	asset, err := assetOutputToPlan(ctx, assetClientOutput)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error get asset when trying to update (refreshing state)",
@@ -190,7 +221,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		return
 	}
 
-	assetInput, err := planToAssetInput(plan)
+	assetInput, err := planToAssetInput(ctx, plan)
 	if err != nil {
 		return
 	}
@@ -206,16 +237,33 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error requesting update from cloud api",
-			"Could not marshal asset parameters json, unexpected error: "+err.Error(),
+			fmt.Sprintf("Could not marshal asset parameters json, unexpected error: %s", err.Error()),
 		)
 		return
 	}
 
-	stateToSet, err := assetOutputToPlan(result)
+	completedAsset, err := utils.WaitForAssetStatusInOperationCompleteState(
+		r.client,
+		ctx,
+		result.Environment.Organization.Id,
+		result.Environment.Id,
+		result.Id,
+	)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error waiting for asset on update",
+			fmt.Sprintf("Error when waiting for asset id: %s: %s", result.Id, err.Error()),
+		)
+		return
+	}
+
+	stateToSet, err := assetOutputToPlan(ctx, completedAsset)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error get asset when trying to update (refreshing state)",
-			"Could get asset when trying to update (refreshing state): "+assetInCloudApi.Id+": "+err.Error())
+			fmt.Sprintf("Could get asset when trying to update (refreshing state): %s: %s", assetInCloudApi.Id, err.Error()),
+		)
 		return
 	}
 
@@ -223,20 +271,6 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	diags = resp.State.Set(ctx, *stateToSet)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	if err := utils.WaitForAssetStatusInOperationCompleteState(
-		r.client,
-		ctx,
-		result.Environment.Organization.Id,
-		result.Environment.Id,
-		result.Id,
-	); err != nil {
-		resp.Diagnostics.AddError(
-			"Error waiting for asset on update",
-			"Error when waiting for asset id"+result.Id+": "+err.Error(),
-		)
 		return
 	}
 }
@@ -254,21 +288,23 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error deleting asset",
-			"Could not delete asset id "+state.Id.Value+": "+err.Error(),
+			fmt.Sprintf("Could not delete asset id %s: %s", state.Id.Value, err.Error()),
 		)
 		return
 	}
 
-	if err := utils.WaitForAssetStatusInOperationCompleteState(
+	_, err = utils.WaitForAssetStatusInOperationCompleteState(
 		r.client,
 		ctx,
 		state.OrganizationId.Value,
 		state.EnvironmentId.Value,
 		state.Id.Value,
-	); err != nil {
+	)
+
+	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error waiting for asset on delete",
-			"Error when waiting for asset id"+state.Id.Value+": "+err.Error(),
+			fmt.Sprintf("Error when waiting for asset id %s: %s", state.Id.Value, err.Error()),
 		)
 		return
 	}

--- a/internal/provider/assets/aws/rds/models.go
+++ b/internal/provider/assets/aws/rds/models.go
@@ -1,11 +1,14 @@
 package rds
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	cac "github.com/aptible/cloud-api-clients/clients/go"
 	"github.com/aptible/terraform-provider-aptible-iaas/internal/client"
+	"github.com/aptible/terraform-provider-aptible-iaas/internal/utils"
 )
 
 var resourceTypeName = "_aws_rds"
@@ -81,7 +84,7 @@ var AssetSchema = map[string]tfsdk.Attribute{
 	},
 }
 
-func planToAssetInput(plan ResourceModel) (cac.AssetInput, error) {
+func planToAssetInput(ctx context.Context, plan ResourceModel) (cac.AssetInput, error) {
 	input := cac.AssetInput{
 		Asset:        client.CompileAsset("aws", "rds", plan.AssetVersion.Value),
 		AssetVersion: plan.AssetVersion.Value,
@@ -96,7 +99,7 @@ func planToAssetInput(plan ResourceModel) (cac.AssetInput, error) {
 	return input, nil
 }
 
-func assetOutputToPlan(output *cac.AssetOutput) (*ResourceModel, error) {
+func assetOutputToPlan(ctx context.Context, output *cac.AssetOutput) (*ResourceModel, error) {
 	outputs := *output.Outputs
 
 	model := &ResourceModel{
@@ -109,8 +112,8 @@ func assetOutputToPlan(output *cac.AssetOutput) (*ResourceModel, error) {
 		Name:             types.String{Value: output.CurrentAssetParameters.Data["name"].(string)},
 		Engine:           types.String{Value: output.CurrentAssetParameters.Data["engine"].(string)},
 		EngineVersion:    types.String{Value: output.CurrentAssetParameters.Data["engine_version"].(string)},
-		UriSecretArn:     types.String{Value: outputs["uri_secret_arn"].Data.(string)},
-		SecretsKmsKeyArn: types.String{Value: outputs["rds_secrets_kms_key_arn"].Data.(string)},
+		UriSecretArn:     types.String{Value: utils.SafeString(outputs["uri_secret_arn"].Data)},
+		SecretsKmsKeyArn: types.String{Value: utils.SafeString(outputs["rds_secrets_kms_key_arn"].Data)},
 	}
 
 	return model, nil

--- a/internal/provider/assets/aws/rds/resources.go
+++ b/internal/provider/assets/aws/rds/resources.go
@@ -65,7 +65,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 
 	tflog.Info(ctx, "Creating asset", map[string]interface{}{"asset": plan})
 
-	assetInput, err := planToAssetInput(plan)
+	assetInput, err := planToAssetInput(ctx, plan)
 	if err != nil {
 		return
 	}
@@ -83,9 +83,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		)
 		return
 	}
-	// for more information on logging from providers, refer to
-	// https://pkg.go.dev/github.com/hashicorp/terraform-plugin-log/tflog
-	tflog.Trace(
+	tflog.Info(
 		ctx, "created asset",
 		map[string]interface{}{
 			"id":     createdAsset.Id,
@@ -93,32 +91,61 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		},
 	)
 
-	result, err := assetOutputToPlan(createdAsset)
+	nextPlan, err := assetOutputToPlan(ctx, createdAsset)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating asset",
-			"Error when creating asset"+plan.Id.Value+": "+err.Error(),
+			fmt.Sprintf(
+				"Error when creating asset %s: %s",
+				plan.Id.Value,
+				err.Error(),
+			),
 		)
 		return
 	}
 
-	diags = resp.State.Set(ctx, result)
+	diags = resp.State.Set(ctx, nextPlan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	if err := utils.WaitForAssetStatusInOperationCompleteState(
+	completedAsset, err := utils.WaitForAssetStatusInOperationCompleteState(
 		r.client,
 		ctx,
-		result.OrganizationId.Value,
-		result.EnvironmentId.Value,
-		result.Id.Value,
-	); err != nil {
+		plan.OrganizationId.Value,
+		plan.EnvironmentId.Value,
+		createdAsset.Id,
+	)
+
+	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error waiting for asset on create",
-			"Error when waiting for asset id"+result.Id.Value+": "+err.Error(),
+			fmt.Sprintf(
+				"Error when waiting for asset id %s: %s",
+				createdAsset.Id,
+				err.Error(),
+			),
 		)
+		return
+	}
+
+	nextPlan, err = assetOutputToPlan(ctx, completedAsset)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating asset",
+			fmt.Sprintf(
+				"Error when creating asset %s: %s",
+				plan.Id.Value,
+				err.Error(),
+			),
+		)
+		return
+	}
+
+	diags = resp.State.Set(ctx, nextPlan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 }
@@ -136,12 +163,16 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading asset",
-			"Could not read ID "+state.Id.Value+": "+err.Error(),
+			fmt.Sprintf(
+				"Error when creating asset %s: %s",
+				state.Id.Value,
+				err.Error(),
+			),
 		)
 		return
 	}
 
-	asset, err := assetOutputToPlan(assetClientOutput)
+	asset, err := assetOutputToPlan(ctx, assetClientOutput)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error get asset when trying to update (refreshing state)",
@@ -190,7 +221,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		return
 	}
 
-	assetInput, err := planToAssetInput(plan)
+	assetInput, err := planToAssetInput(ctx, plan)
 	if err != nil {
 		return
 	}
@@ -206,16 +237,33 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error requesting update from cloud api",
-			"Could not marshal asset parameters json, unexpected error: "+err.Error(),
+			fmt.Sprintf("Could not marshal asset parameters json, unexpected error: %s", err.Error()),
 		)
 		return
 	}
 
-	stateToSet, err := assetOutputToPlan(result)
+	completedAsset, err := utils.WaitForAssetStatusInOperationCompleteState(
+		r.client,
+		ctx,
+		result.Environment.Organization.Id,
+		result.Environment.Id,
+		result.Id,
+	)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error waiting for asset on update",
+			fmt.Sprintf("Error when waiting for asset id: %s: %s", result.Id, err.Error()),
+		)
+		return
+	}
+
+	stateToSet, err := assetOutputToPlan(ctx, completedAsset)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error get asset when trying to update (refreshing state)",
-			"Could get asset when trying to update (refreshing state): "+assetInCloudApi.Id+": "+err.Error())
+			fmt.Sprintf("Could get asset when trying to update (refreshing state): %s: %s", assetInCloudApi.Id, err.Error()),
+		)
 		return
 	}
 
@@ -223,20 +271,6 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	diags = resp.State.Set(ctx, *stateToSet)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	if err := utils.WaitForAssetStatusInOperationCompleteState(
-		r.client,
-		ctx,
-		result.Environment.Organization.Id,
-		result.Environment.Id,
-		result.Id,
-	); err != nil {
-		resp.Diagnostics.AddError(
-			"Error waiting for asset on update",
-			"Error when waiting for asset id"+result.Id+": "+err.Error(),
-		)
 		return
 	}
 }
@@ -254,21 +288,23 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error deleting asset",
-			"Could not delete asset id "+state.Id.Value+": "+err.Error(),
+			fmt.Sprintf("Could not delete asset id %s: %s", state.Id.Value, err.Error()),
 		)
 		return
 	}
 
-	if err := utils.WaitForAssetStatusInOperationCompleteState(
+	_, err = utils.WaitForAssetStatusInOperationCompleteState(
 		r.client,
 		ctx,
 		state.OrganizationId.Value,
 		state.EnvironmentId.Value,
 		state.Id.Value,
-	); err != nil {
+	)
+
+	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error waiting for asset on delete",
-			"Error when waiting for asset id"+state.Id.Value+": "+err.Error(),
+			fmt.Sprintf("Error when waiting for asset id %s: %s", state.Id.Value, err.Error()),
 		)
 		return
 	}

--- a/internal/provider/assets/aws/redis/models.go
+++ b/internal/provider/assets/aws/redis/models.go
@@ -1,11 +1,14 @@
 package redis
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	cac "github.com/aptible/cloud-api-clients/clients/go"
 	"github.com/aptible/terraform-provider-aptible-iaas/internal/client"
+	"github.com/aptible/terraform-provider-aptible-iaas/internal/utils"
 )
 
 var resourceTypeName = "_aws_redis"
@@ -84,7 +87,7 @@ var AssetSchema = map[string]tfsdk.Attribute{
 	},
 }
 
-func planToAssetInput(plan ResourceModel) (cac.AssetInput, error) {
+func planToAssetInput(ctx context.Context, plan ResourceModel) (cac.AssetInput, error) {
 	input := cac.AssetInput{
 		Asset:        client.CompileAsset("aws", "elasticache_redis", plan.AssetVersion.Value),
 		AssetVersion: plan.AssetVersion.Value,
@@ -100,7 +103,7 @@ func planToAssetInput(plan ResourceModel) (cac.AssetInput, error) {
 	return input, nil
 }
 
-func assetOutputToPlan(output *cac.AssetOutput) (*ResourceModel, error) {
+func assetOutputToPlan(ctx context.Context, output *cac.AssetOutput) (*ResourceModel, error) {
 	outputs := *output.Outputs
 
 	model := &ResourceModel{
@@ -114,8 +117,8 @@ func assetOutputToPlan(output *cac.AssetOutput) (*ResourceModel, error) {
 		Description:       types.String{Value: output.CurrentAssetParameters.Data["description"].(string)},
 		SnapshotWindow:    types.String{Value: output.CurrentAssetParameters.Data["snapshot_window"].(string)},
 		MaintenanceWindow: types.String{Value: output.CurrentAssetParameters.Data["maintenance_window"].(string)},
-		UriSecretArn:      types.String{Value: outputs["elasticache_token_secret_arn"].Data.(string)},
-		SecretsKmsKeyArn:  types.String{Value: outputs["elasticache_token_kms_key_arn"].Data.(string)},
+		UriSecretArn:      types.String{Value: utils.SafeString(outputs["elasticache_token_secret_arn"].Data)},
+		SecretsKmsKeyArn:  types.String{Value: utils.SafeString(outputs["elasticache_token_kms_key_arn"].Data)},
 	}
 
 	return model, nil

--- a/internal/provider/assets/aws/redis/resources.go
+++ b/internal/provider/assets/aws/redis/resources.go
@@ -65,7 +65,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 
 	tflog.Info(ctx, "Creating asset", map[string]interface{}{"asset": plan})
 
-	assetInput, err := planToAssetInput(plan)
+	assetInput, err := planToAssetInput(ctx, plan)
 	if err != nil {
 		return
 	}
@@ -83,9 +83,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		)
 		return
 	}
-	// for more information on logging from providers, refer to
-	// https://pkg.go.dev/github.com/hashicorp/terraform-plugin-log/tflog
-	tflog.Trace(
+	tflog.Info(
 		ctx, "created asset",
 		map[string]interface{}{
 			"id":     createdAsset.Id,
@@ -93,32 +91,61 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		},
 	)
 
-	result, err := assetOutputToPlan(createdAsset)
+	nextPlan, err := assetOutputToPlan(ctx, createdAsset)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating asset",
-			"Error when creating asset"+plan.Id.Value+": "+err.Error(),
+			fmt.Sprintf(
+				"Error when creating asset %s: %s",
+				plan.Id.Value,
+				err.Error(),
+			),
 		)
 		return
 	}
 
-	diags = resp.State.Set(ctx, result)
+	diags = resp.State.Set(ctx, nextPlan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	if err := utils.WaitForAssetStatusInOperationCompleteState(
+	completedAsset, err := utils.WaitForAssetStatusInOperationCompleteState(
 		r.client,
 		ctx,
-		result.OrganizationId.Value,
-		result.EnvironmentId.Value,
-		result.Id.Value,
-	); err != nil {
+		plan.OrganizationId.Value,
+		plan.EnvironmentId.Value,
+		createdAsset.Id,
+	)
+
+	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error waiting for asset on create",
-			"Error when waiting for asset id"+result.Id.Value+": "+err.Error(),
+			fmt.Sprintf(
+				"Error when waiting for asset id %s: %s",
+				createdAsset.Id,
+				err.Error(),
+			),
 		)
+		return
+	}
+
+	nextPlan, err = assetOutputToPlan(ctx, completedAsset)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating asset",
+			fmt.Sprintf(
+				"Error when creating asset %s: %s",
+				plan.Id.Value,
+				err.Error(),
+			),
+		)
+		return
+	}
+
+	diags = resp.State.Set(ctx, nextPlan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 }
@@ -136,12 +163,16 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading asset",
-			"Could not read ID "+state.Id.Value+": "+err.Error(),
+			fmt.Sprintf(
+				"Error when creating asset %s: %s",
+				state.Id.Value,
+				err.Error(),
+			),
 		)
 		return
 	}
 
-	asset, err := assetOutputToPlan(assetClientOutput)
+	asset, err := assetOutputToPlan(ctx, assetClientOutput)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error get asset when trying to update (refreshing state)",
@@ -190,7 +221,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		return
 	}
 
-	assetInput, err := planToAssetInput(plan)
+	assetInput, err := planToAssetInput(ctx, plan)
 	if err != nil {
 		return
 	}
@@ -206,16 +237,33 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error requesting update from cloud api",
-			"Could not marshal asset parameters json, unexpected error: "+err.Error(),
+			fmt.Sprintf("Could not marshal asset parameters json, unexpected error: %s", err.Error()),
 		)
 		return
 	}
 
-	stateToSet, err := assetOutputToPlan(result)
+	completedAsset, err := utils.WaitForAssetStatusInOperationCompleteState(
+		r.client,
+		ctx,
+		result.Environment.Organization.Id,
+		result.Environment.Id,
+		result.Id,
+	)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error waiting for asset on update",
+			fmt.Sprintf("Error when waiting for asset id: %s: %s", result.Id, err.Error()),
+		)
+		return
+	}
+
+	stateToSet, err := assetOutputToPlan(ctx, completedAsset)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error get asset when trying to update (refreshing state)",
-			"Could get asset when trying to update (refreshing state): "+assetInCloudApi.Id+": "+err.Error())
+			fmt.Sprintf("Could get asset when trying to update (refreshing state): %s: %s", assetInCloudApi.Id, err.Error()),
+		)
 		return
 	}
 
@@ -223,20 +271,6 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	diags = resp.State.Set(ctx, *stateToSet)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	if err := utils.WaitForAssetStatusInOperationCompleteState(
-		r.client,
-		ctx,
-		result.Environment.Organization.Id,
-		result.Environment.Id,
-		result.Id,
-	); err != nil {
-		resp.Diagnostics.AddError(
-			"Error waiting for asset on update",
-			"Error when waiting for asset id"+result.Id+": "+err.Error(),
-		)
 		return
 	}
 }
@@ -254,21 +288,23 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error deleting asset",
-			"Could not delete asset id "+state.Id.Value+": "+err.Error(),
+			fmt.Sprintf("Could not delete asset id %s: %s", state.Id.Value, err.Error()),
 		)
 		return
 	}
 
-	if err := utils.WaitForAssetStatusInOperationCompleteState(
+	_, err = utils.WaitForAssetStatusInOperationCompleteState(
 		r.client,
 		ctx,
 		state.OrganizationId.Value,
 		state.EnvironmentId.Value,
 		state.Id.Value,
-	); err != nil {
+	)
+
+	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error waiting for asset on delete",
-			"Error when waiting for asset id"+state.Id.Value+": "+err.Error(),
+			fmt.Sprintf("Error when waiting for asset id %s: %s", state.Id.Value, err.Error()),
 		)
 		return
 	}

--- a/internal/provider/assets/aws/vpc/models.go
+++ b/internal/provider/assets/aws/vpc/models.go
@@ -1,6 +1,8 @@
 package vpc
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -53,7 +55,7 @@ var AssetSchema = map[string]tfsdk.Attribute{
 	},
 }
 
-func planToAssetInput(plan ResourceModel) (cac.AssetInput, error) {
+func planToAssetInput(ctx context.Context, plan ResourceModel) (cac.AssetInput, error) {
 	input := cac.AssetInput{
 		Asset:        client.CompileAsset("aws", "vpc", plan.AssetVersion.Value),
 		AssetVersion: plan.AssetVersion.Value,
@@ -65,7 +67,7 @@ func planToAssetInput(plan ResourceModel) (cac.AssetInput, error) {
 	return input, nil
 }
 
-func assetOutputToPlan(output *cac.AssetOutput) (*ResourceModel, error) {
+func assetOutputToPlan(ctx context.Context, output *cac.AssetOutput) (*ResourceModel, error) {
 	vpc := &ResourceModel{
 		Id:             types.String{Value: output.Id},
 		AssetVersion:   types.String{Value: output.AssetVersion},

--- a/internal/provider/assets/aws/vpc/resources.go
+++ b/internal/provider/assets/aws/vpc/resources.go
@@ -65,7 +65,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 
 	tflog.Info(ctx, "Creating asset", map[string]interface{}{"asset": plan})
 
-	assetInput, err := planToAssetInput(plan)
+	assetInput, err := planToAssetInput(ctx, plan)
 	if err != nil {
 		return
 	}
@@ -83,9 +83,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		)
 		return
 	}
-	// for more information on logging from providers, refer to
-	// https://pkg.go.dev/github.com/hashicorp/terraform-plugin-log/tflog
-	tflog.Trace(
+	tflog.Info(
 		ctx, "created asset",
 		map[string]interface{}{
 			"id":     createdAsset.Id,
@@ -93,32 +91,61 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		},
 	)
 
-	result, err := assetOutputToPlan(createdAsset)
+	nextPlan, err := assetOutputToPlan(ctx, createdAsset)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating asset",
-			"Error when creating asset"+plan.Id.Value+": "+err.Error(),
+			fmt.Sprintf(
+				"Error when creating asset %s: %s",
+				plan.Id.Value,
+				err.Error(),
+			),
 		)
 		return
 	}
 
-	diags = resp.State.Set(ctx, result)
+	diags = resp.State.Set(ctx, nextPlan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	if err := utils.WaitForAssetStatusInOperationCompleteState(
+	completedAsset, err := utils.WaitForAssetStatusInOperationCompleteState(
 		r.client,
 		ctx,
-		result.OrganizationId.Value,
-		result.EnvironmentId.Value,
-		result.Id.Value,
-	); err != nil {
+		plan.OrganizationId.Value,
+		plan.EnvironmentId.Value,
+		createdAsset.Id,
+	)
+
+	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error waiting for asset on create",
-			"Error when waiting for asset id"+result.Id.Value+": "+err.Error(),
+			fmt.Sprintf(
+				"Error when waiting for asset id %s: %s",
+				createdAsset.Id,
+				err.Error(),
+			),
 		)
+		return
+	}
+
+	nextPlan, err = assetOutputToPlan(ctx, completedAsset)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating asset",
+			fmt.Sprintf(
+				"Error when creating asset %s: %s",
+				plan.Id.Value,
+				err.Error(),
+			),
+		)
+		return
+	}
+
+	diags = resp.State.Set(ctx, nextPlan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 }
@@ -136,12 +163,16 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading asset",
-			"Could not read ID "+state.Id.Value+": "+err.Error(),
+			fmt.Sprintf(
+				"Error when creating asset %s: %s",
+				state.Id.Value,
+				err.Error(),
+			),
 		)
 		return
 	}
 
-	asset, err := assetOutputToPlan(assetClientOutput)
+	asset, err := assetOutputToPlan(ctx, assetClientOutput)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error get asset when trying to update (refreshing state)",
@@ -190,7 +221,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		return
 	}
 
-	assetInput, err := planToAssetInput(plan)
+	assetInput, err := planToAssetInput(ctx, plan)
 	if err != nil {
 		return
 	}
@@ -206,16 +237,33 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error requesting update from cloud api",
-			"Could not marshal asset parameters json, unexpected error: "+err.Error(),
+			fmt.Sprintf("Could not marshal asset parameters json, unexpected error: %s", err.Error()),
 		)
 		return
 	}
 
-	stateToSet, err := assetOutputToPlan(result)
+	completedAsset, err := utils.WaitForAssetStatusInOperationCompleteState(
+		r.client,
+		ctx,
+		result.Environment.Organization.Id,
+		result.Environment.Id,
+		result.Id,
+	)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error waiting for asset on update",
+			fmt.Sprintf("Error when waiting for asset id: %s: %s", result.Id, err.Error()),
+		)
+		return
+	}
+
+	stateToSet, err := assetOutputToPlan(ctx, completedAsset)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error get asset when trying to update (refreshing state)",
-			"Could get asset when trying to update (refreshing state): "+assetInCloudApi.Id+": "+err.Error())
+			fmt.Sprintf("Could get asset when trying to update (refreshing state): %s: %s", assetInCloudApi.Id, err.Error()),
+		)
 		return
 	}
 
@@ -223,20 +271,6 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	diags = resp.State.Set(ctx, *stateToSet)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	if err := utils.WaitForAssetStatusInOperationCompleteState(
-		r.client,
-		ctx,
-		result.Environment.Organization.Id,
-		result.Environment.Id,
-		result.Id,
-	); err != nil {
-		resp.Diagnostics.AddError(
-			"Error waiting for asset on update",
-			"Error when waiting for asset id"+result.Id+": "+err.Error(),
-		)
 		return
 	}
 }
@@ -254,21 +288,23 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error deleting asset",
-			"Could not delete asset id "+state.Id.Value+": "+err.Error(),
+			fmt.Sprintf("Could not delete asset id %s: %s", state.Id.Value, err.Error()),
 		)
 		return
 	}
 
-	if err := utils.WaitForAssetStatusInOperationCompleteState(
+	_, err = utils.WaitForAssetStatusInOperationCompleteState(
 		r.client,
 		ctx,
 		state.OrganizationId.Value,
 		state.EnvironmentId.Value,
 		state.Id.Value,
-	); err != nil {
+	)
+
+	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error waiting for asset on delete",
-			"Error when waiting for asset id"+state.Id.Value+": "+err.Error(),
+			fmt.Sprintf("Error when waiting for asset id %s: %s", state.Id.Value, err.Error()),
 		)
 		return
 	}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	cloud_api_client "github.com/aptible/cloud-api-clients/clients/go"
+	cac "github.com/aptible/cloud-api-clients/clients/go"
 	"github.com/aptible/terraform-provider-aptible-iaas/internal/client"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -19,17 +19,16 @@ var TimeToFail = 30 * time.Minute
 
 // AssetStatusesThatIndicateCompletion - these statuses indicate the asset requested is now in a somewhat
 // final state and is ready for operations
-var AssetStatusesThatIndicateCompletion = []cloud_api_client.AssetStatus{
-	cloud_api_client.ASSETSTATUS_FAILED,
-	cloud_api_client.ASSETSTATUS_DEPLOYED,
-	cloud_api_client.ASSETSTATUS_DESTROYED,
+var AssetStatusesThatIndicateCompletion = []cac.AssetStatus{
+	cac.ASSETSTATUS_DEPLOYED,
+	cac.ASSETSTATUS_DESTROYED,
 }
 
 // ErrorTimeOutOnAssetStatus - error that's returned when asset waiter times out
 var ErrorTimeOutOnAssetStatus = fmt.Errorf("timed out when waiting for asset status")
 
-func WaitForAssetStatusInOperationCompleteState(client client.CloudClient, ctx context.Context, orgId, envId, id string) error {
-	tflog.Trace(
+func WaitForAssetStatusInOperationCompleteState(client client.CloudClient, ctx context.Context, orgId, envId, id string) (*cac.AssetOutput, error) {
+	tflog.Info(
 		ctx, "waiting for asset status",
 		map[string]interface{}{
 			"id":    id,
@@ -49,22 +48,27 @@ func WaitForAssetStatusInOperationCompleteState(client client.CloudClient, ctx c
 					"orgId":            orgId,
 					"totalTimeRunning": totalTimeRunning,
 				})
-			return ErrorTimeOutOnAssetStatus
+			return nil, ErrorTimeOutOnAssetStatus
 		}
 		asset, err := client.DescribeAsset(ctx, orgId, envId, id)
 		if err != nil {
-			return err
+			return nil, err
 		}
+
+		if asset.Status == cac.ASSETSTATUS_FAILED {
+			return nil, fmt.Errorf("Asset status FAILED %s", id)
+		}
+
 		for _, completedOperationStatus := range AssetStatusesThatIndicateCompletion {
 			if completedOperationStatus == asset.Status {
 				tflog.Info(ctx, "Completed waiting for operation, in state ready for further operations")
 				// if operation is completed, just break, we're done!
-				return nil
+				return asset, nil
 			}
 		}
 		// actively wait for status
 		time.Sleep(DefaultTimeToWait)
-		tflog.Trace(ctx,
+		tflog.Info(ctx,
 			"Still waiting for status on provided asset",
 			map[string]interface{}{
 				"id":               id,
@@ -72,5 +76,14 @@ func WaitForAssetStatusInOperationCompleteState(client client.CloudClient, ctx c
 				"orgId":            orgId,
 				"totalTimeRunning": totalTimeRunning,
 			})
+	}
+}
+
+func SafeString(obj interface{}) string {
+	switch val := obj.(type) {
+	case string:
+		return val
+	default:
+		return ""
 	}
 }


### PR DESCRIPTION
The wait function was not returning the latest asset and we were not
updating the asset in state.  This is a problem because when an asset
goes from `REQUESTED` to `COMPLETED` there could be different `outputs`
which are required for other asset resources.

Furthermore, we were not differentiating between `FAILED` and `COMPLETED`
statuses when waiting for an asset.  This means that an asset could be
failed to be created but terraform continues to the next step in its
plan.

We also added a `make resource` command to copy `acm/resources.go` to all
other aws asset packages.  This simply copy and pastes acm/resources to
all other aws assets which will help us make changes across all assets
until we come up with a better solution.

I also fixed a type conversion error for redis and rds when converting
an asset output to a plan object.