### PR TITLE
refactor: simplified makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,47 +4,24 @@ NAMESPACE = aptible
 NAME = aptible-iaas
 BINARY = terraform-provider-${NAME}
 VERSION = 0.0.0+local
-TARGET = darwin_amd64
-LOCAL_ARCH ?= amd64
-LOCAL_TARGET ?= darwin_${LOCAL_ARCH}
+GOOS ?= darwin
+GOARCH ?= amd64
+TARGET ?= ${GOOS}_${GOARCH}
 
 default: install
 
 build:
-	go build -o ${BINARY}
-
-release:
-	GOOS=darwin GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_darwin_amd64
-	GOOS=freebsd GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_freebsd_386
-	GOOS=freebsd GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_freebsd_amd64
-	GOOS=freebsd GOARCH=arm go build -o ./bin/${BINARY}_${VERSION}_freebsd_arm
-	GOOS=linux GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_linux_386
-	GOOS=linux GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_linux_amd64
-	GOOS=linux GOARCH=arm go build -o ./bin/${BINARY}_${VERSION}_linux_arm
-	GOOS=openbsd GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_openbsd_386
-	GOOS=openbsd GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_openbsd_amd64
-	GOOS=solaris GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_solaris_amd64
-	GOOS=windows GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_windows_386
-	GOOS=windows GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_windows_amd64
-
-
-build-dev:
 	# https://www.terraform.io/plugin/debugging#debugging-caveats
-	GOOS=darwin GOARCH=${LOCAL_ARCH} go build -gcflags="all=-N -l" -o ./bin/${BINARY}_${VERSION}_${LOCAL_TARGET}
-.PHONY: build-dev
+	GOOS=${GOOS} GOARCH=${GOARCH} go build -o -gcflags="all=-N -l" -o ./bin/${BINARY}_${VERSION}_${TARGET}
 
 clean:
 	rm -rf "$$HOME/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}" || true
 .PHONY: clean
 
-local-install: clean build-dev
-	mkdir -p "$$HOME/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/$(LOCAL_TARGET)"
-	cp ./bin/${BINARY}_${VERSION}_${LOCAL_TARGET} "$$HOME/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/$(LOCAL_TARGET)"
+install: clean build
+	mkdir -p "$$HOME/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${TARGET}"
+	cp ./bin/${BINARY}_${VERSION}_${TARGET} "$$HOME/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${TARGET}"
 	@echo "Installed as provider aptible.com/aptible/aptible-iaas version 0.0.0+local"
-
-install: build
-	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
-	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 
 test:
 	go test -i $(TEST) || exit 1
@@ -80,3 +57,17 @@ debug:
 dc:
 	dlv connect 0.0.0.0:33000
 .PHONY: debug-connect
+
+release:
+	GOOS=darwin GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_darwin_amd64
+	GOOS=freebsd GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_freebsd_386
+	GOOS=freebsd GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_freebsd_amd64
+	GOOS=freebsd GOARCH=arm go build -o ./bin/${BINARY}_${VERSION}_freebsd_arm
+	GOOS=linux GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_linux_386
+	GOOS=linux GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_linux_amd64
+	GOOS=linux GOARCH=arm go build -o ./bin/${BINARY}_${VERSION}_linux_arm
+	GOOS=openbsd GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_openbsd_386
+	GOOS=openbsd GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_openbsd_amd64
+	GOOS=solaris GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_solaris_amd64
+	GOOS=windows GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_windows_386
+	GOOS=windows GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_windows_amd64

--- a/README.md
+++ b/README.md
@@ -3,13 +3,19 @@
 To install the provider locally, run:
 
 ```bash
-make local-install
+make
 ```
 
-Or, for ARM 64 architectures:
+Or, for mac ARM 64 architectures:
 
 ```bash
-LOCAL_ARCH=arm64 make local-install
+GOOS=darwin GOARCH=arm64 make
+```
+
+Linux:
+
+```bash
+GOOS=linux GOARCH=amd64 make
 ```
 
 ## Run


### PR DESCRIPTION
The commit makes it so the default `make` command will install the terraform plugin.  We also renamed some env vars in an effort to make it more clear what they do.