### PR TITLE
remove asset version

### DIFF
--- a/examples/aws/main.tf
+++ b/examples/aws/main.tf
@@ -57,7 +57,6 @@ data "aptible_environment" "env" {
 resource "aptible_aws_secret" "secrets" {
   environment_id  = data.aptible_environment.env.id
   organization_id = data.aptible_organization.org.id
-  asset_version   = "v0.26.1"
   name            = "nextsecrets"
   secret_string   = jsonencode(var.secrets)
 }
@@ -65,7 +64,6 @@ resource "aptible_aws_secret" "secrets" {
 resource "aptible_aws_vpc" "network" {
   environment_id  = data.aptible_environment.env.id
   organization_id = data.aptible_organization.org.id
-  asset_version   = "v0.26.1"
   name            = "nextvpc" # optional
 }
 
@@ -74,7 +72,6 @@ resource "aptible_aws_rds" "db" {
   organization_id = data.aptible_organization.org.id
   vpc_name        = aptible_aws_vpc.network.name
 
-  asset_version   = "v0.26.1" # force new
   name            = "nextdb" # force new
   engine          = "postgres" # force new
   engine_version  = "14" # force new
@@ -85,7 +82,6 @@ resource "aptible_aws_redis" "cache" {
   organization_id     = data.aptible_organization.org.id
   vpc_name            = aptible_aws_vpc.network.name
 
-  asset_version       = "v0.26.1"
   name                = "nextcache"
 
   description         = "integration testing" # optional
@@ -97,7 +93,6 @@ resource "aptible_aws_acm" "cert" {
   environment_id    = data.aptible_environment.env.id
   organization_id   = data.aptible_organization.org.id
 
-  asset_version     = "v0.26.1"
   fqdn              = var.fqdn
 
   validation_method = "DNS" # optional
@@ -139,7 +134,6 @@ resource "aptible_aws_ecs_web" "web" {
   vpc_name            = aptible_aws_vpc.network.name
   depends_on          = [time_sleep.wait_30_seconds]
 
-  asset_version       = "v0.26.1"
   name                = "nextapp"
   container_name      = "nextapp"
   container_image     = "quay.io/aptible/deploy-demo-app"
@@ -182,7 +176,6 @@ resource "aptible_aws_ecs_compute" "worker" {
   organization_id     = data.aptible_organization.org.id
   vpc_name            = aptible_aws_vpc.network.name
 
-  asset_version       = "v0.26.1"
   name                = "nextworker"
   container_name      = "nextworker"
   container_image     = "quay.io/aptible/deploy-demo-app"

--- a/examples/connections/main.tf
+++ b/examples/connections/main.tf
@@ -29,7 +29,6 @@ provider "aptible" {
 resource "aptible_aws_vpc" "network" {
   environment_id  = var.env_id
   organization_id = var.org_id
-  asset_version   = "v0.26.1"
   name            = "conn" # optional
 }
 
@@ -37,7 +36,6 @@ resource "aptible_aws_acm" "cert" {
   environment_id    = var.env_id
   organization_id   = var.org_id
 
-  asset_version     = "v0.26.1"
   fqdn              = var.fqdn
 
   validation_method = "DNS" # optional
@@ -48,7 +46,6 @@ resource "aptible_aws_ecs_web" "web" {
   organization_id     = var.env_id
   vpc_name            = aptible_aws_vpc.network.name
 
-  asset_version       = "v0.26.1"
   name                = "nginx"
   container_name      = "nginx"
   container_image     = "nginx/alpine"

--- a/examples/null/main.tf
+++ b/examples/null/main.tf
@@ -25,7 +25,6 @@ resource "aptible_null_simple" "network" {
 
   asset_type = "simple"
   asset_platform = "null"
-  asset_version  = "latest"
 
   name                   = "my_null"
 }

--- a/examples/private_registry/main.tf
+++ b/examples/private_registry/main.tf
@@ -57,7 +57,6 @@ data "aptible_environment" "env" {
 resource "aptible_aws_secret" "registry" {
   environment_id  = data.aptible_environment.env.id
   organization_id = data.aptible_organization.org.id
-  asset_version   = "v0.26.1"
   name            = "registry"
   secret_string   = jsonencode(var.secret_registry)
 }
@@ -65,7 +64,6 @@ resource "aptible_aws_secret" "registry" {
 resource "aptible_aws_vpc" "network" {
   environment_id  = data.aptible_environment.env.id
   organization_id = data.aptible_organization.org.id
-  asset_version   = "v0.26.1"
   name            = "priv" # optional
 }
 
@@ -73,7 +71,6 @@ resource "aptible_aws_acm" "cert" {
   environment_id    = data.aptible_environment.env.id
   organization_id   = data.aptible_organization.org.id
 
-  asset_version     = "v0.26.1"
   fqdn              = var.fqdn
 
   validation_method = "DNS" # optional
@@ -115,7 +112,6 @@ resource "aptible_aws_ecs_web" "web" {
   vpc_name            = aptible_aws_vpc.network.name
   depends_on          = [time_sleep.wait_30_seconds]
 
-  asset_version       = "v0.26.1"
   name                = "privimg"
   container_name      = "privimg"
   container_image     = "ghcr.io/aptible/docker-hello-world-private:main"

--- a/internal/provider/asset/aws/acm/models.go
+++ b/internal/provider/asset/aws/acm/models.go
@@ -10,6 +10,7 @@ import (
 
 	cac "github.com/aptible/cloud-api-clients/clients/go"
 	"github.com/aptible/terraform-provider-aptible-iaas/internal/client"
+	"github.com/aptible/terraform-provider-aptible-iaas/internal/provider/asset/util"
 )
 
 var resourceTypeName = "_aws_acm"
@@ -66,7 +67,7 @@ var AssetSchema = map[string]tfsdk.Attribute{
 	},
 	"asset_version": {
 		Type:     types.StringType,
-		Required: true,
+		Computed: true,
 	},
 	"fqdn": {
 		Type:     types.StringType,
@@ -111,8 +112,8 @@ var AssetSchema = map[string]tfsdk.Attribute{
 
 func planToAssetInput(ctx context.Context, plan ResourceModel) (cac.AssetInput, error) {
 	input := cac.AssetInput{
-		Asset:        client.CompileAsset("aws", "acm_certificate", plan.AssetVersion.Value),
-		AssetVersion: plan.AssetVersion.Value,
+		Asset:        client.CompileAsset("aws", "acm_certificate", assetutil.DefaultAssetVersion),
+		AssetVersion: assetutil.DefaultAssetVersion,
 		AssetParameters: map[string]interface{}{
 			"fqdn":              plan.Fqdn.Value,
 			"validation_method": plan.ValidationMethod.Value,

--- a/internal/provider/asset/aws/ecs_compute/models.go
+++ b/internal/provider/asset/aws/ecs_compute/models.go
@@ -10,6 +10,7 @@ import (
 
 	cac "github.com/aptible/cloud-api-clients/clients/go"
 	"github.com/aptible/terraform-provider-aptible-iaas/internal/client"
+	assetutil "github.com/aptible/terraform-provider-aptible-iaas/internal/provider/asset/util"
 	"github.com/aptible/terraform-provider-aptible-iaas/internal/util"
 )
 
@@ -74,7 +75,7 @@ var AssetSchema = map[string]tfsdk.Attribute{
 	},
 	"asset_version": {
 		Type:     types.StringType,
-		Required: true,
+		Computed: true,
 	},
 	"name": {
 		Type:     types.StringType,
@@ -134,13 +135,13 @@ func planToAssetInput(ctx context.Context, plan ResourceModel) (cac.AssetInput, 
 	}
 
 	params := map[string]interface{}{
-		"vpc_name":                      plan.VpcName.Value,
-		"name":                          plan.Name.Value,
-		"container_name":                plan.ContainerName.Value,
-		"container_image":               plan.ContainerImage.Value,
-		"container_port":                plan.ContainerPort.Value,
-		"container_command":             cmd,
-		"environment_secrets":           secrets,
+		"vpc_name":            plan.VpcName.Value,
+		"name":                plan.Name.Value,
+		"container_name":      plan.ContainerName.Value,
+		"container_image":     plan.ContainerImage.Value,
+		"container_port":      plan.ContainerPort.Value,
+		"container_command":   cmd,
+		"environment_secrets": secrets,
 	}
 
 	if !plan.ContainerRegistrySecretArn.IsNull() && !plan.ContainerRegistrySecretArn.IsUnknown() {
@@ -149,8 +150,8 @@ func planToAssetInput(ctx context.Context, plan ResourceModel) (cac.AssetInput, 
 
 	// TODO HACK: https://aptible.slack.com/archives/C03C2STPTDX/p1664478414991299
 	input := cac.AssetInput{
-		Asset:           client.CompileAsset("aws", "ecs_compute_service", plan.AssetVersion.Value),
-		AssetVersion:    plan.AssetVersion.Value,
+		Asset:           client.CompileAsset("aws", "ecs_compute_service", assetutil.DefaultAssetVersion),
+		AssetVersion:    assetutil.DefaultAssetVersion,
 		AssetParameters: params,
 	}
 

--- a/internal/provider/asset/aws/ecs_web/models.go
+++ b/internal/provider/asset/aws/ecs_web/models.go
@@ -12,6 +12,7 @@ import (
 
 	cac "github.com/aptible/cloud-api-clients/clients/go"
 	"github.com/aptible/terraform-provider-aptible-iaas/internal/client"
+	assetutil "github.com/aptible/terraform-provider-aptible-iaas/internal/provider/asset/util"
 	"github.com/aptible/terraform-provider-aptible-iaas/internal/util"
 )
 
@@ -80,7 +81,7 @@ var AssetSchema = map[string]tfsdk.Attribute{
 	},
 	"asset_version": {
 		Type:     types.StringType,
-		Required: true,
+		Computed: true,
 	},
 	"name": {
 		Type:     types.StringType,
@@ -178,8 +179,8 @@ func planToAssetInput(ctx context.Context, plan ResourceModel) (cac.AssetInput, 
 	}
 
 	input := cac.AssetInput{
-		Asset:           client.CompileAsset("aws", "ecs_web_service", plan.AssetVersion.Value),
-		AssetVersion:    plan.AssetVersion.Value,
+		Asset:           client.CompileAsset("aws", "ecs_web_service", assetutil.DefaultAssetVersion),
+		AssetVersion:    assetutil.DefaultAssetVersion,
 		AssetParameters: params,
 	}
 

--- a/internal/provider/asset/aws/rds/models.go
+++ b/internal/provider/asset/aws/rds/models.go
@@ -8,6 +8,7 @@ import (
 
 	cac "github.com/aptible/cloud-api-clients/clients/go"
 	"github.com/aptible/terraform-provider-aptible-iaas/internal/client"
+	assetutil "github.com/aptible/terraform-provider-aptible-iaas/internal/provider/asset/util"
 	"github.com/aptible/terraform-provider-aptible-iaas/internal/util"
 )
 
@@ -58,7 +59,7 @@ var AssetSchema = map[string]tfsdk.Attribute{
 	},
 	"asset_version": {
 		Type:     types.StringType,
-		Required: true,
+		Computed: true,
 	},
 	"name": {
 		Type:     types.StringType,
@@ -86,8 +87,8 @@ var AssetSchema = map[string]tfsdk.Attribute{
 
 func planToAssetInput(ctx context.Context, plan ResourceModel) (cac.AssetInput, error) {
 	input := cac.AssetInput{
-		Asset:        client.CompileAsset("aws", "rds", plan.AssetVersion.Value),
-		AssetVersion: plan.AssetVersion.Value,
+		Asset:        client.CompileAsset("aws", "rds", assetutil.DefaultAssetVersion),
+		AssetVersion: assetutil.DefaultAssetVersion,
 		AssetParameters: map[string]interface{}{
 			"vpc_name":       plan.VpcName.Value,
 			"name":           plan.Name.Value,

--- a/internal/provider/asset/aws/redis/models.go
+++ b/internal/provider/asset/aws/redis/models.go
@@ -8,6 +8,7 @@ import (
 
 	cac "github.com/aptible/cloud-api-clients/clients/go"
 	"github.com/aptible/terraform-provider-aptible-iaas/internal/client"
+	assetutil "github.com/aptible/terraform-provider-aptible-iaas/internal/provider/asset/util"
 	"github.com/aptible/terraform-provider-aptible-iaas/internal/util"
 )
 
@@ -59,7 +60,7 @@ var AssetSchema = map[string]tfsdk.Attribute{
 	},
 	"asset_version": {
 		Type:     types.StringType,
-		Required: true,
+		Computed: true,
 	},
 	"name": {
 		Type:     types.StringType,
@@ -89,8 +90,8 @@ var AssetSchema = map[string]tfsdk.Attribute{
 
 func planToAssetInput(ctx context.Context, plan ResourceModel) (cac.AssetInput, error) {
 	input := cac.AssetInput{
-		Asset:        client.CompileAsset("aws", "elasticache_redis", plan.AssetVersion.Value),
-		AssetVersion: plan.AssetVersion.Value,
+		Asset:        client.CompileAsset("aws", "elasticache_redis", assetutil.DefaultAssetVersion),
+		AssetVersion: assetutil.DefaultAssetVersion,
 		AssetParameters: map[string]interface{}{
 			"vpc_name":           plan.VpcName.Value,
 			"name":               plan.Name.Value,

--- a/internal/provider/asset/aws/secret/models.go
+++ b/internal/provider/asset/aws/secret/models.go
@@ -8,6 +8,7 @@ import (
 
 	cac "github.com/aptible/cloud-api-clients/clients/go"
 	"github.com/aptible/terraform-provider-aptible-iaas/internal/client"
+	assetutil "github.com/aptible/terraform-provider-aptible-iaas/internal/provider/asset/util"
 	"github.com/aptible/terraform-provider-aptible-iaas/internal/util"
 )
 
@@ -51,7 +52,7 @@ var AssetSchema = map[string]tfsdk.Attribute{
 	},
 	"asset_version": {
 		Type:     types.StringType,
-		Required: true,
+		Computed: true,
 	},
 	"name": {
 		Type:     types.StringType,
@@ -75,8 +76,8 @@ var AssetSchema = map[string]tfsdk.Attribute{
 
 func planToAssetInput(ctx context.Context, plan ResourceModel) (cac.AssetInput, error) {
 	input := cac.AssetInput{
-		Asset:        client.CompileAsset("aws", "secret_manager", plan.AssetVersion.Value),
-		AssetVersion: plan.AssetVersion.Value,
+		Asset:        client.CompileAsset("aws", "secret_manager", assetutil.DefaultAssetVersion),
+		AssetVersion: assetutil.DefaultAssetVersion,
 		AssetParameters: map[string]interface{}{
 			"name":          plan.Name.Value,
 			"secret_string": plan.SecretString.Value,

--- a/internal/provider/asset/aws/vpc/models.go
+++ b/internal/provider/asset/aws/vpc/models.go
@@ -8,6 +8,7 @@ import (
 
 	cac "github.com/aptible/cloud-api-clients/clients/go"
 	"github.com/aptible/terraform-provider-aptible-iaas/internal/client"
+	assetutil "github.com/aptible/terraform-provider-aptible-iaas/internal/provider/asset/util"
 )
 
 var resourceTypeName = "_aws_vpc"
@@ -47,7 +48,7 @@ var AssetSchema = map[string]tfsdk.Attribute{
 	},
 	"asset_version": {
 		Type:     types.StringType,
-		Required: true,
+		Computed: true,
 	},
 	"name": {
 		Type:     types.StringType,
@@ -57,8 +58,8 @@ var AssetSchema = map[string]tfsdk.Attribute{
 
 func planToAssetInput(ctx context.Context, plan ResourceModel) (cac.AssetInput, error) {
 	input := cac.AssetInput{
-		Asset:        client.CompileAsset("aws", "vpc", plan.AssetVersion.Value),
-		AssetVersion: plan.AssetVersion.Value,
+		Asset:        client.CompileAsset("aws", "vpc", assetutil.DefaultAssetVersion),
+		AssetVersion: assetutil.DefaultAssetVersion,
 		AssetParameters: map[string]interface{}{
 			"name": plan.Name.Value,
 		},

--- a/internal/provider/asset/util/util.go
+++ b/internal/provider/asset/util/util.go
@@ -1,0 +1,3 @@
+package assetutil
+
+var DefaultAssetVersion = "latest"


### PR DESCRIPTION
https://app.shortcut.com/aptible/story/6767/convert-asset-version-to-computed-field

```
{
  "version": 4,
  "terraform_version": "1.3.1",
  "serial": 9,
  "lineage": "5269a001-2d84-502b-6baf-5e3c513ad012",
  "outputs": {},
  "resources": [
    {
      "mode": "managed",
      "type": "aptible_aws_acm",
      "name": "cert",
      "provider": "provider[\"aptible.com/aptible/aptible-iaas\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "asset_version": "v0.26.1",
            "status": "DEPLOYED"
          },
          "sensitive_attributes": []
        }
      ]
    },
    {
      "mode": "managed",
      "type": "aptible_aws_vpc",
      "name": "network",
      "provider": "provider[\"aptible.com/aptible/aptible-iaas\"]",
      "instances": [
        {
          "schema_version": 0,
          "attributes": {
            "asset_version": "v0.26.1",
            "status": "DEPLOYED"
          },
          "sensitive_attributes": []
        }
      ]
    }
  ],
  "check_results": null
}

```