### PR TITLE
feat: added token extraction from local FS under constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,32 @@ GOOS=linux GOARCH=amd64 make
 
 ## Run
 
-```bash
+Go to an example workspace as below:
+
+```sh
 cd ./examples/aws
+```
+
+### Logging in
+
+You can get credentials to work with this provider by:
+
+* setting an environment variable with `APTIBLE_TOKEN` before any `terraform` command (ex: `terraform plan`)
+* log in with the [Aptible CLI](https://deploy-docs.aptible.com/docs/cli) (`aptible login`)
+* setting a `token` stanza in your provider (like below)
+
+```hcl
+provider "aptible" {
+  host = var.aptible_host
+  token = var.token  # <--- SET THIS VALUE
+}
+```
+
+### Running Terraform Commands
+
+You should now be able to use your terraform commands without interruption
+
+```bash
 terraform init
 terraform apply
 ```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -59,6 +60,37 @@ type providerData struct {
 	Host  types.String `tfsdk:"host"`
 }
 
+func extractValueFromTokensJson(config *providerData) string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		// skip over this, silently?
+		return config.Token.Value
+	}
+	tokensJson, err := os.ReadFile(homeDir + "/.aptible/tokens.json")
+	if err != nil {
+		return config.Token.Value
+	}
+
+	var output map[string]interface{}
+	if err = json.Unmarshal(tokensJson, &output); err != nil {
+		return config.Token.Value
+	}
+
+	// find if in host and specified
+	if !config.Host.Null {
+		if _, found := output[config.Host.Value]; found {
+			return output[config.Host.Value].(string)
+		}
+	}
+
+	// fall back to default host if no host specified
+	if _, found := output["https://auth.aptible.com"]; found {
+		return output["https://auth.aptible.com"].(string)
+	}
+
+	return config.Token.Value
+}
+
 func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
 	// Retrieve Provider data from configuration
 	var config providerData
@@ -79,8 +111,15 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 		return
 	}
 
+	// APTIBLE_TOKEN retrieval
+	// 1 - try to use the token passed in on the provider stanza
+	// 2 - by default, try to use the environment variable
+	// 3 - if no environment variable specified, fall back to API token
 	if config.Token.Null {
 		token = os.Getenv("APTIBLE_TOKEN")
+		if token == "" {
+			token = extractValueFromTokensJson(&config)
+		}
 	} else {
 		token = config.Token.Value
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -50,14 +50,19 @@ func (p *Provider) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics)
 				Type:     types.StringType,
 				Optional: true,
 			},
+			"auth_host": {
+				Type:     types.StringType,
+				Optional: true,
+			},
 		},
 	}, nil
 }
 
 // providerData schema struct
 type providerData struct {
-	Token types.String `tfsdk:"token"`
-	Host  types.String `tfsdk:"host"`
+	Token    types.String `tfsdk:"token"`
+	AuthHost types.String `tfsdk:"auth_host"`
+	Host     types.String `tfsdk:"host"`
 }
 
 func extractValueFromTokensJson(config *providerData) string {
@@ -77,9 +82,9 @@ func extractValueFromTokensJson(config *providerData) string {
 	}
 
 	// find if in host and specified
-	if !config.Host.Null {
-		if _, found := output[config.Host.Value]; found {
-			return output[config.Host.Value].(string)
+	if !config.AuthHost.Null {
+		if _, found := output[config.AuthHost.Value]; found {
+			return output[config.AuthHost.Value].(string)
 		}
 	}
 


### PR DESCRIPTION
This should cover three cases:

1. Pulling from stanza by default
2. Pulling from environment variable if stanza empty
3. Pulling from tokens.json in default aptible path if that too is populated (be sure to use the host first, then fallback to default host otherwise)

---

Question for review - should errors fail loudly in this phase? Many folks may not have that file set with login and this may prove annoying