### PR TITLE
fix: added secrets manager add flow

### DIFF
--- a/test/basic/secret_create/main.tf
+++ b/test/basic/secret_create/main.tf
@@ -25,5 +25,5 @@ resource "aptible_aws_secret" "secret" {
   organization_id = data.aptible_organization.org.id
 
   name          = var.secret_name
-  secret_string = var.secret_string
+  secret_string = var.secret_value
 }

--- a/test/basic/secret_create/main.tf
+++ b/test/basic/secret_create/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_providers {
+    aptible = {
+      source = "aptible.com/aptible/aptible-iaas"
+    }
+  }
+}
+
+provider "aptible" {
+  host = var.aptible_host
+}
+
+data "aptible_organization" "org" {
+  id = var.organization_id
+}
+
+data "aptible_environment" "env" {
+  id     = var.environment_id
+  org_id = data.aptible_organization.org.id
+}
+
+
+resource "aptible_aws_secret" "secret" {
+  environment_id  = data.aptible_environment.env.id
+  organization_id = data.aptible_organization.org.id
+
+  name          = var.secret_name
+  secret_string = var.secret_string
+}

--- a/test/basic/secret_create/outputs.tf
+++ b/test/basic/secret_create/outputs.tf
@@ -1,0 +1,7 @@
+output "secret_id" {
+  value = aptible_aws_secret.secret.id
+}
+
+output "secret_arn" {
+  value = aptible_aws_secret.secret.arn
+}

--- a/test/basic/secret_create/secret_create_test.go
+++ b/test/basic/secret_create/secret_create_test.go
@@ -2,6 +2,7 @@ package secret_create
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"testing"
 
@@ -18,7 +19,7 @@ func cleanupAndAssert(t *testing.T, terraformOptions *terraform.Options) {
 	// test / assert all failures here
 }
 
-func TestSecretCreate(t *testing.T) {
+func TestSecretCreateSimpleString(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: ".",
 
@@ -27,7 +28,7 @@ func TestSecretCreate(t *testing.T) {
 			"environment_id":  os.Getenv("ENVIRONMENT_ID"),
 			"aptible_host":    os.Getenv("APTIBLE_HOST"),
 			"secret_name":     "testing-secret",
-			"secret_string":   "some-kind-of-secret-string",
+			"secret_value":    "some-kind-of-secret-string",
 		},
 	})
 	defer cleanupAndAssert(t, terraformOptions)
@@ -58,4 +59,51 @@ func TestSecretCreate(t *testing.T) {
 	// check aws asset state
 	secretValue := terratest_aws.GetSecretValue(t, "us-east-1", secretArn)
 	assert.Equal(t, secretValue, "some-kind-of-secret-string")
+}
+
+func TestSecretCreateJSON(t *testing.T) {
+	secretEncodedValue, _ := json.Marshal(map[string]string{
+		"test-value-1": "test1",
+		"test-value-2": "test2",
+	})
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: ".",
+
+		Vars: map[string]interface{}{
+			"organization_id": os.Getenv("ORGANIZATION_ID"),
+			"environment_id":  os.Getenv("ENVIRONMENT_ID"),
+			"aptible_host":    os.Getenv("APTIBLE_HOST"),
+			"secret_name":     "testing-secret",
+			"secret_value":    string(secretEncodedValue),
+		},
+	})
+	defer cleanupAndAssert(t, terraformOptions)
+	terraform.InitAndApply(t, terraformOptions)
+
+	c := client.NewClient(
+		true,
+		os.Getenv("APTIBLE_HOST"),
+		os.Getenv("APTIBLE_TOKEN"),
+	)
+	ctx := context.Background()
+
+	secretId := terraform.Output(t, terraformOptions, "secret_id")
+
+	// check cloud api's understanding of asset
+	secretAsset, secretAptibleErr := c.DescribeAsset(
+		ctx,
+		os.Getenv("ORGANIZATION_ID"),
+		os.Getenv("ENVIRONMENT_ID"),
+		secretId,
+	)
+	assert.Nil(t, secretAptibleErr)
+	assert.Equal(t, secretAsset.Id, secretId)
+	assert.Equal(t, secretAsset.Status, cac.ASSETSTATUS_DEPLOYED)
+
+	secretArn := terraform.Output(t, terraformOptions, "secret_arn")
+
+	// check aws asset state
+	secretValue := terratest_aws.GetSecretValue(t, "us-east-1", secretArn)
+	assert.Equal(t, secretValue, string(secretEncodedValue))
 }

--- a/test/basic/secret_create/secret_create_test.go
+++ b/test/basic/secret_create/secret_create_test.go
@@ -1,0 +1,61 @@
+package secret_create
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	terratest_aws "github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+
+	cac "github.com/aptible/cloud-api-clients/clients/go"
+	"github.com/aptible/terraform-provider-aptible-iaas/internal/client"
+)
+
+func cleanupAndAssert(t *testing.T, terraformOptions *terraform.Options) {
+	terraform.Destroy(t, terraformOptions)
+	// test / assert all failures here
+}
+
+func TestSecretCreate(t *testing.T) {
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: ".",
+
+		Vars: map[string]interface{}{
+			"organization_id": os.Getenv("ORGANIZATION_ID"),
+			"environment_id":  os.Getenv("ENVIRONMENT_ID"),
+			"aptible_host":    os.Getenv("APTIBLE_HOST"),
+			"secret_name":     "testing-secret",
+			"secret_string":   "some-kind-of-secret-string",
+		},
+	})
+	defer cleanupAndAssert(t, terraformOptions)
+	terraform.InitAndApply(t, terraformOptions)
+
+	c := client.NewClient(
+		true,
+		os.Getenv("APTIBLE_HOST"),
+		os.Getenv("APTIBLE_TOKEN"),
+	)
+	ctx := context.Background()
+
+	secretId := terraform.Output(t, terraformOptions, "secret_id")
+
+	// check cloud api's understanding of asset
+	secretAsset, secretAptibleErr := c.DescribeAsset(
+		ctx,
+		os.Getenv("ORGANIZATION_ID"),
+		os.Getenv("ENVIRONMENT_ID"),
+		secretId,
+	)
+	assert.Nil(t, secretAptibleErr)
+	assert.Equal(t, secretAsset.Id, secretId)
+	assert.Equal(t, secretAsset.Status, cac.ASSETSTATUS_DEPLOYED)
+
+	secretArn := terraform.Output(t, terraformOptions, "secret_arn")
+
+	// check aws asset state
+	secretValue := terratest_aws.GetSecretValue(t, "us-east-1", secretArn)
+	assert.Equal(t, secretValue, "some-kind-of-secret-string")
+}

--- a/test/basic/secret_create/variables.tf
+++ b/test/basic/secret_create/variables.tf
@@ -14,6 +14,6 @@ variable "secret_name" {
   type = string
 }
 
-variable "secret_string" {
+variable "secret_value" {
   type = string
 }

--- a/test/basic/secret_create/variables.tf
+++ b/test/basic/secret_create/variables.tf
@@ -1,0 +1,19 @@
+variable "organization_id" {
+  type = string
+}
+
+variable "environment_id" {
+  type = string
+}
+
+variable "aptible_host" {
+  type = string
+}
+
+variable "secret_name" {
+  type = string
+}
+
+variable "secret_string" {
+  type = string
+}


### PR DESCRIPTION
- [x] plain string test
- [x] json test


string assertion apparently works

<img width="932" alt="image" src="https://user-images.githubusercontent.com/2961973/200854934-b760e1d0-7ca6-4a6a-a1a2-e47eced3a800.png">

Added JSON test but honestly redundant except how AWS deals with it themselves apparenlty:

<img width="854" alt="image" src="https://user-images.githubusercontent.com/2961973/200859073-21786ccf-72df-4fca-a420-ad682665fe86.png">

<img width="487" alt="image" src="https://user-images.githubusercontent.com/2961973/200859885-7db5134a-9697-446b-bf55-db381735f1f7.png">

----

<img width="654" alt="image" src="https://user-images.githubusercontent.com/2961973/200860872-9e13e277-5d17-4587-8c78-3919ff6d6a69.png">

