### PR TITLE
fix: possible fix for empty payloads on asset with retry logic and warnings for users

### DIFF
--- a/internal/util/utils.go
+++ b/internal/util/utils.go
@@ -59,7 +59,7 @@ func WaitForAssetStatusInOperationCompleteState(client client.CloudClient, ctx c
 
 		// Note: below block occurs when we get back an empty payload from the server but no error status
 		if asset == nil && invalidServerResponseRetries > 3 {
-			return nil, fmt.Errorf("asset retrieval failed because server replied with an un-actionable" +
+			return nil, fmt.Errorf("asset retrieval failed because server replied with an un-actionable " +
 				"or empty response. please enable TF_LOG=debug to view more details")
 		} else if asset == nil {
 			invalidServerResponseRetries += 1


### PR DESCRIPTION
This should guard against potential invalid server responses (likely blips), unable to duplicate and error up if our client repeatedly fails to bubble up a valid error. 

Instead of logs, it might make sense to supply diags into this function so waiters can appropriately send back warnings to the end user in diags instead of tflog