### PR TITLE
Run automated tests against staging

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,7 +1,9 @@
 name: E2E Testing
 
 on:
-  push:
+  workflow_dispatch:
+  pull_request:
+    types: ["ready_for_review", "opened"]
 
 env:
   AWS_DEFAULT_REGION: us-east-1

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -53,7 +53,9 @@ jobs:
         run: |
           TOKEN=$(echo $APTIBLE_PASSWORD | ./test/scripts/auth.sh $APTIBLE_USERNAME)
           echo "APTIBLE_TOKEN=$TOKEN" >> $GITHUB_ENV
-          cat $GITHUB_ENV
+        env:
+          APTIBLE_PASSWORD: ${{ secrets.APTIBLE_PASSWORD }}
+          APTIBLE_USERNAME: ${{ secrets.APTIBLE_USERNAME }}
 
       - name: Build Provider
         run: GOOS=linux make install

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -51,7 +51,9 @@ jobs:
 
       - name: Configure Aptible credentials
         run: |
-          echo "APTIBLE_TOKEN=$(echo $APTIBLE_PASSWORD | ./test/scripts/auth.sh $APTIBLE_USERNAME)" >> $GITHUB_ENV
+          TOKEN=$(echo $APTIBLE_PASSWORD | ./test/scripts/auth.sh $APTIBLE_USERNAME)
+          echo "APTIBLE_TOKEN=$TOKEN" >> $GITHUB_ENV
+          cat $GITHUB_ENV
 
       - name: Build Provider
         run: GOOS=linux make install

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,60 @@
+name: E2E Testing
+
+on:
+  push:
+
+env:
+  AWS_DEFAULT_REGION: us-east-1
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    environment: cloud_staging
+
+    strategy:
+      fail-fast: false
+
+      # Reduced to 2 while testing.
+      max-parallel: 2
+
+      matrix:
+        include:
+          - test: vpc_create
+            env_id: "e4eecaee-6ce5-4915-92d0-98a9fe036ab4"
+            aws_account_id: "257348118889"
+
+          - test: vpc_update
+            env_id: "89ca29f6-e245-4ac0-b796-1943d65d5933"
+            aws_account_id: "604856548006"
+
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ^1.0.0
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.18.0"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::${{ matrix.aws_account_id }}:role/github-actions-e2e-testing
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Configure Aptible credentials
+        run: |
+          echo "APTIBLE_TOKEN=$(echo $APTIBLE_PASSWORD | ./test/scripts/auth.sh $APTIBLE_USERNAME)" >> $GITHUB_ENV
+
+      - name: Build Provider
+        run: make build
+
+      - name: Run ${{ matrix.test }} Test
+        run: make ci-test-${{ matrix.test }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -5,6 +5,7 @@ on:
 
 env:
   AWS_DEFAULT_REGION: us-east-1
+  AWS_DNS_ROLE: "arn:aws:iam::821755571104:role/aptible-cloud-staging-dns-cross-account"
 
 jobs:
   test:
@@ -16,10 +17,9 @@ jobs:
 
       matrix:
         include:
-          # Need to figure out how to manage DNS
-          # - test: acm-dns-validated-create
-          #   env_id: "5bb16655-4102-49f1-88c8-20f198fc139a"
-          #   aws_account_id: "395100626517"
+          - test: acm-dns-validated-create
+            env_id: "5bb16655-4102-49f1-88c8-20f198fc139a"
+            aws_account_id: "395100626517"
 
           - test: acm-non-validated-create
             env_id: "3991abc1-e98e-4f4f-8de1-66e8d7e0c5dd"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -104,6 +104,7 @@ jobs:
 
       - name: Run ${{ matrix.test }} Test
         run: make ci-test-${{ matrix.test }}
+        timeout-minutes: 130
         env:
           APTIBLE_HOST: ${{ secrets.APTIBLE_HOST }}
           ORGANIZATION_ID: "e6c7394d-054c-454f-9710-dc02fa7406d3"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,11 +14,49 @@ jobs:
     strategy:
       fail-fast: false
 
-      # Reduced to 2 while testing.
-      max-parallel: 2
-
       matrix:
         include:
+          # Need to figure out how to manage DNS
+          # - test: acm-dns-validated-create
+          #   env_id: "5bb16655-4102-49f1-88c8-20f198fc139a"
+          #   aws_account_id: "395100626517"
+
+          - test: acm-none-validated-create
+            env_id: "3991abc1-e98e-4f4f-8de1-66e8d7e0c5dd"
+            aws_account_id: "309087580932"
+
+          - test: ecs_compute_create
+            env_id: "18f97b0c-7054-4041-a064-6cc46c241cb3"
+            aws_account_id: "100952742100"
+
+          - test: ecs_compute_update
+            env_id: "23f58fa1-c190-4f82-a68c-fd1b56b2cbfe"
+            aws_account_id: "759853141917"
+
+          - test: ecs_web_create
+            env_id: "e675979c-cb76-4b78-b6e2-dd4ca7b91342"
+            aws_account_id: "692148248699"
+
+          - test: elasticache_create
+            env_id: "abe891e3-4e08-43af-8525-b290bb175f84"
+            aws_account_id: "917738356426"
+
+          - test: elasticache_update
+            env_id: "03440b0b-9b84-4004-80c9-5cdc6e768f8e"
+            aws_account_id: "327177179188"
+
+          - test: rds
+            env_id: "e9a067d9-8fa6-44c9-9a80-cf76aca8b878"
+            aws_account_id: "740682447574"
+
+          - test: secret_create
+            env_id: "413f7b2f-6d73-4412-8828-ac49f595efd3"
+            aws_account_id: "908740948823"
+
+          - test: secret_update
+            env_id: "f3363014-0b95-47a4-97b4-a5b92fb1c005"
+            aws_account_id: "453862071053"
+
           - test: vpc_create
             env_id: "e4eecaee-6ce5-4915-92d0-98a9fe036ab4"
             aws_account_id: "257348118889"
@@ -45,7 +83,10 @@ jobs:
           go-version: ">=1.18.0"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        # The @v1-node16 branch should be used until v2 comes out. v1 uses an old github action runtime
+        # and causes deprecation notices, but AWS isn't updating it until v2 is released.
+        # https://github.com/aws-actions/configure-aws-credentials/issues/489
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: arn:aws:iam::${{ matrix.aws_account_id }}:role/github-actions-e2e-testing
           aws-region: ${{ env.AWS_DEFAULT_REGION }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -54,7 +54,7 @@ jobs:
           echo "APTIBLE_TOKEN=$(echo $APTIBLE_PASSWORD | ./test/scripts/auth.sh $APTIBLE_USERNAME)" >> $GITHUB_ENV
 
       - name: Build Provider
-        run: make build
+        run: make install
 
       - name: Run ${{ matrix.test }} Test
         run: make ci-test-${{ matrix.test }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -54,7 +54,7 @@ jobs:
           echo "APTIBLE_TOKEN=$(echo $APTIBLE_PASSWORD | ./test/scripts/auth.sh $APTIBLE_USERNAME)" >> $GITHUB_ENV
 
       - name: Build Provider
-        run: make install
+        run: GOOS=linux make install
 
       - name: Run ${{ matrix.test }} Test
         run: make ci-test-${{ matrix.test }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -64,3 +64,5 @@ jobs:
         run: make ci-test-${{ matrix.test }}
         env:
           APTIBLE_HOST: ${{ secrets.APTIBLE_HOST }}
+          ORGANIZATION_ID: "e6c7394d-054c-454f-9710-dc02fa7406d3"
+          ENVIRONMENT_ID: ${{ matrix.env_id }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -62,3 +62,5 @@ jobs:
 
       - name: Run ${{ matrix.test }} Test
         run: make ci-test-${{ matrix.test }}
+        env:
+          APTIBLE_HOST: ${{ secrets.APTIBLE_HOST }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,7 +21,7 @@ jobs:
           #   env_id: "5bb16655-4102-49f1-88c8-20f198fc139a"
           #   aws_account_id: "395100626517"
 
-          - test: acm-none-validated-create
+          - test: acm-non-validated-create
             env_id: "3991abc1-e98e-4f4f-8de1-66e8d7e0c5dd"
             aws_account_id: "309087580932"
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -37,7 +37,8 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: ^1.0.0
+          terraform_version: ~1.3.0
+          terraform_wrapper: false
 
       - uses: actions/setup-go@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ release:
 # CI/CD
 
 define run_service_test
-    cd test/basic/${1} && go test -v || exit 1
+    cd test/basic/${1} && go test -v -timeout 3600s || exit 1
 endef
 
 ci-test-%:

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ release:
 # CI/CD
 
 define run_service_test
-    cd test/basic/${1} && go test -v -timeout 3600s || exit 1
+    cd test/basic/${1} && go test -v -timeout 7200s || exit 1
 endef
 
 ci-test-%:

--- a/Makefile
+++ b/Makefile
@@ -83,3 +83,13 @@ release:
 	GOOS=solaris GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_solaris_amd64
 	GOOS=windows GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_windows_386
 	GOOS=windows GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_windows_amd64
+
+
+# CI/CD
+
+define run_service_test
+    cd test/basic/${1} && go test -v || exit 1
+endef
+
+ci-test-%:
+	$(call run_service_test,$(@F:ci-test-%=%))

--- a/test/basic/acm-dns-validated-create/acm_test.go
+++ b/test/basic/acm-dns-validated-create/acm_test.go
@@ -22,9 +22,9 @@ func cleanupAndAssert(t *testing.T, terraformOptions *terraform.Options) {
 }
 
 func checkSetup() {
-	_, dnsAccountSet := os.LookupEnv("DNS_AWS_ACCOUNT_ID")
+	_, dnsAccountSet := os.LookupEnv("AWS_DNS_ROLE")
 	if !dnsAccountSet {
-		fmt.Printf("DNS_AWS_ACCOUNT_ID environment variable not set\n")
+		fmt.Printf("AWS_DNS_ROLE environment variable not set\n")
 		os.Exit(1)
 	}
 }
@@ -36,7 +36,7 @@ func TestACMDnsValidated(t *testing.T) {
 			"organization_id": os.Getenv("ORGANIZATION_ID"),
 			"environment_id":  os.Getenv("ENVIRONMENT_ID"),
 			"aptible_host":    os.Getenv("APTIBLE_HOST"),
-			"dns_account_id":  os.Getenv("DNS_AWS_ACCOUNT_ID"),
+			"aws_dns_role":    os.Getenv("AWS_DNS_ROLE"),
 			"domain":          "aptible-cloud-staging.com",
 			"subdomain":       "fake-testing-cert-domain",
 		},
@@ -77,8 +77,7 @@ func TestACMDnsValidated(t *testing.T) {
 
 	// check aws asset state
 	certArn := terraform.Output(t, terraformOptions, "cert_arn")
-	certAccountId := terraform.Output(t, terraformOptions, "aptible_aws_account_id")
-	session, sessionErr := terratest_aws.CreateAwsSessionFromRole("us-east-1", fmt.Sprintf("arn:aws:iam::%s:role/OrganizationAccountAccessRole", certAccountId))
+	session, sessionErr := terratest_aws.NewAuthenticatedSession("us-east-1")
 	if sessionErr != nil {
 		fmt.Println(sessionErr.Error())
 		os.Exit(1)

--- a/test/basic/acm-dns-validated-create/main.tf
+++ b/test/basic/acm-dns-validated-create/main.tf
@@ -9,14 +9,14 @@ terraform {
   }
 }
 
-variable "dns_account_id" {
+variable "aws_dns_role" {
   type = string
 }
 provider "aws" {
   alias  = "dns_account"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${var.dns_account_id}:role/OrganizationAccountAccessRole"
+    role_arn = var.aws_dns_role
   }
 }
 

--- a/test/basic/acm-non-validated-create/acm_test.go
+++ b/test/basic/acm-non-validated-create/acm_test.go
@@ -57,8 +57,8 @@ func TestACMNonValidated(t *testing.T) {
 
 	// check aws asset state
 	certArn := terraform.Output(t, terraformOptions, "cert_arn")
-	certAccountId := terraform.Output(t, terraformOptions, "aptible_aws_account_id")
-	session, sessionErr := terratest_aws.CreateAwsSessionFromRole("us-east-1", fmt.Sprintf("arn:aws:iam::%s:role/OrganizationAccountAccessRole", certAccountId))
+	session, sessionErr := terratest_aws.NewAuthenticatedSession("us-east-1")
+
 	if sessionErr != nil {
 		fmt.Println(sessionErr.Error())
 		os.Exit(1)

--- a/test/basic/ecs_web_create/ecs_web_create_test.go
+++ b/test/basic/ecs_web_create/ecs_web_create_test.go
@@ -21,7 +21,7 @@ import (
 
 func checkSetup() {
 	for _, envVarKey := range []string{
-		"DNS_AWS_ACCOUNT_ID",
+		"AWS_DNS_ROLE",
 	} {
 		_, envVar := os.LookupEnv(envVarKey)
 		if !envVar {
@@ -114,7 +114,7 @@ func TestECSWebCreatePublicImage(t *testing.T) {
 			"organization_id":   os.Getenv("ORGANIZATION_ID"),
 			"environment_id":    os.Getenv("ENVIRONMENT_ID"),
 			"aptible_host":      os.Getenv("APTIBLE_HOST"),
-			"dns_account_id":    os.Getenv("DNS_AWS_ACCOUNT_ID"),
+			"aws_dns_role":      os.Getenv("AWS_DNS_ROLE"),
 			"ecs_name":          "ecs-pub-web-test",
 			"container_command": []string{"nginx", "-g", "daemon off;"},
 			"container_image":   "nginx",
@@ -136,10 +136,6 @@ func TestECSWebCreatePublicImage(t *testing.T) {
 		os.Getenv("APTIBLE_TOKEN"),
 	)
 	ctx := context.Background()
-
-	aptibleAccountId := terraform.Output(t, terraformOptions, "aptible_aws_account_id")
-	aptibleAccountRole := fmt.Sprintf("arn:aws:iam::%s:role/OrganizationAccountAccessRole", aptibleAccountId)
-	os.Setenv(terratest_aws.AuthAssumeRoleEnvVar, aptibleAccountRole)
 
 	vpcId := terraform.Output(t, terraformOptions, "vpc_id")
 	vpcAsset, vpcAws, vpcErr := getAptibleAndAWSVPCs(t, ctx, c, vpcId, "testecs-pub-img-web-vpc")

--- a/test/basic/ecs_web_create/main.tf
+++ b/test/basic/ecs_web_create/main.tf
@@ -13,7 +13,7 @@ provider "aws" {
   alias  = "dns_account"
   region = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::${var.dns_account_id}:role/OrganizationAccountAccessRole"
+    role_arn = var.aws_dns_role
   }
 }
 

--- a/test/basic/ecs_web_create/variables.tf
+++ b/test/basic/ecs_web_create/variables.tf
@@ -1,4 +1,4 @@
-variable "dns_account_id" {
+variable "aws_dns_role" {
   type = string
 }
 

--- a/test/scripts/auth.sh
+++ b/test/scripts/auth.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Username as the first argument.
+username=$1
+
+# Password from STDIN.
+password=$(cat -)
+
+# Run the curl command and dump to jq to grab the token.
+TOKEN=$(curl --header "Content-Type: application/json" \
+  --silent \
+  --request POST \
+  --data "{\"username\":\"$username\",\"password\":\"$password\",\"grant_type\":\"password\",\"scope\":\"manage\",\"expires_in\":43200,\"_source\":\"dashboard\"}" \
+  https://auth-api-master.aptible-staging.com/tokens | jq -r '.access_token')
+
+# If no token then exit with error
+if [[ -z $TOKEN || $TOKEN == "null" ]]; then
+  exit 1
+fi
+
+echo $TOKEN


### PR DESCRIPTION
This PR gets all of the tests running, completing [this epic](https://app.shortcut.com/aptible/epic/7747?cf_workflow=500000673&ct_workflow=all).

During testing this was triggered on every push, but the final commit changes it to run on "ready for review", "pr open", or via a manual trigger.

Additionally since this repository is public we require approval from someone on the @aptible/engineers team to approve any runs of the workflow, and the workflow can only run from our fork. This prevents people from pushing up code to try and exfiltrate credentials.